### PR TITLE
Remake Certification elements

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -3575,12 +3575,6 @@
         "type": "object",
         "description": "A certification for a product",
         "properties": {
-          "ProdCertificationName": {
-            "$ref": "#/components/schemas/ProdCertificationName"
-          },
-          "ProdCertificationValue": {
-            "$ref": "#/components/schemas/ProdCertificationValue"
-          },
           "CertificationAgency": {
             "$ref": "#/components/schemas/CertificationAgency"
           },
@@ -3589,42 +3583,23 @@
           },
           "Description": {
             "$ref": "#/components/schemas/Description"
+          },
+          "CertificationDate": {
+            "$ref": "#/components/schemas/CertificationDate"
+          },
+          "CertificationExpirationDate": {
+            "$ref": "#/components/schemas/CertificationExpirationDate"
+          },
+          "CertificationName": {
+            "$ref": "#/components/schemas/CertificationName"
+          },
+          "CertificationTypeProduct": {
+            "$ref": "#/components/schemas/CertificationTypeProduct"
+          },
+          "CertificateValue": {
+            "$ref": "#/components/schemas/CertificateValue"
           }
         }
-      },
-      "ProdCertificationName": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TaxonomyElementString"
-          },
-          {
-            "type": "object",
-            "description": "The name of the certification",
-            "x-ob-item-type": "stdi:stringItemType",
-            "x-ob-usage-tips": "",
-            "x-ob-sample-value": {
-              "Value": "Quality Certification"
-            },
-            "x-ob-item-type-group": ""
-          }
-        ]
-      },
-      "ProdCertificationValue": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TaxonomyElementString"
-          },
-          {
-            "type": "object",
-            "description": "The value of the certification",
-            "x-ob-item-type": "stdi:stringItemType",
-            "x-ob-usage-tips": "",
-            "x-ob-sample-value": {
-              "Value": "ISO 9001"
-            },
-            "x-ob-item-type-group": ""
-          }
-        ]
       },
       "CertificationAgency": {
         "type": "object",
@@ -4733,23 +4708,6 @@
             "x-ob-sample-value": {
               "Unit": "US Dollar",
               "Value": "1000"
-            },
-            "x-ob-item-type-group": ""
-          }
-        ]
-      },
-      "ProdCertificationType": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TaxonomyElementString"
-          },
-          {
-            "type": "object",
-            "description": "An enumerated list of the possible certifications that a product can have.",
-            "x-ob-item-type": "CertificationTypeProductItemType",
-            "x-ob-usage-tips": "",
-            "x-ob-sample-value": {
-              "Value": "UL1741"
             },
             "x-ob-item-type-group": ""
           }
@@ -8452,6 +8410,81 @@
         "items": {
           "$ref": "#/components/schemas/Warranty"
         }
+      },
+      "CertificationDate": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementString"
+          },
+          {
+            "type": "object",
+            "description": "The date on which a certification is made.",
+            "x-ob-item-type": "stdi:dateItemType",
+            "x-ob-item-type-group": "",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": ""
+          }
+        ]
+      },
+      "CertificationExpirationDate": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementString"
+          },
+          {
+            "type": "object",
+            "description": "The expiration date of a certification.",
+            "x-ob-item-type": "stdi:dateItemType",
+            "x-ob-item-type-group": "",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": ""
+          }
+        ]
+      },
+      "CertificationName": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementString"
+          },
+          {
+            "type": "object",
+            "description": "The name of the certification.",
+            "x-ob-item-type": "stdi:stringItemType",
+            "x-ob-item-type-group": "",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": ""
+          }
+        ]
+      },
+      "CertificateValue": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementString"
+          },
+          {
+            "type": "object",
+            "description": "The document identifier of a certification.",
+            "x-ob-item-type": "stdi:stringItemType",
+            "x-ob-item-type-group": "",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": "ABC-123"
+          }
+        ]
+      },
+      "CertificationTypeProduct": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementString"
+          },
+          {
+            "type": "object",
+            "description": "A value from the enumerated list of the possible certifications that a product can have.",
+            "x-ob-item-type": "CertificationTypeProductItemType",
+            "x-ob-item-type-group": "",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": "UL1741"
+          }
+        ]
       }
     }
   },

--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -4746,7 +4746,7 @@
           {
             "type": "object",
             "description": "An enumerated list of the possible certifications that a product can have.",
-            "x-ob-item-type": "ProdCertificationTypeItemType",
+            "x-ob-item-type": "CertificationTypeProductItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
               "Value": "UL1741"
@@ -13260,7 +13260,7 @@
         }
       }
     },
-    "ProdCertificationTypeItemType": {
+    "CertificationTypeProductItemType": {
       "description": "",
       "enums": {
         "IEC61215": {


### PR DESCRIPTION
Adds:

CertificationDate
CertificationExpirationDate
The data for CertificationDate and CertificationExpirationDate were being encoded in the StartTime and EndTime metadata for ProdCertificationValue.

Replaces

ProdCertificationName with CertificationName
ProdCertificationValue with CertificateValue
ProdCertificationType with CertificationTypeProduct

Item type ProdCertificationTypeItemType changed to CertificationTypeProductItemType
