### PR TITLE
Add TaxonomyElementArray to schema

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -6887,6 +6887,30 @@
         },
         "x-ob-usage-tips": ""
       },
+      "TaxonomyElementArray": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/components/schemas/Value"
+          },
+          "Unit": {
+            "$ref": "#/components/schemas/Unit"
+          },
+          "Decimals": {
+            "$ref": "#/components/schemas/Decimals"
+          },
+          "Precision": {
+            "$ref": "#/components/schemas/Precision"
+          },
+          "StartTime": {
+            "$ref": "#/components/schemas/StartTime"
+          },
+          "EndTime": {
+            "$ref": "#/components/schemas/EndTime"
+          }
+        },
+        "x-ob-usage-tips": ""
+      },
       "Azimuth": {
         "allOf": [
           {


### PR DESCRIPTION
TaxonomyElementArray is added to schema for use with OB Taxonomy Element Array. 