### PR TITLE
Correcting schema-validator file path arguments

### DIFF
--- a/.github/workflows/schema-validator.yaml
+++ b/.github/workflows/schema-validator.yaml
@@ -28,4 +28,4 @@ jobs:
         run: npm install -g ibm-openapi-validator
       - name: Run validator
         working-directory: ./.github
-        run: lint-openapi ../Master-OB-OpenAPI.json -c ./configs/validator/.validaterc -r ./configs/validator/.spectral.yaml
+        run: lint-openapi ../Master-OB-OpenAPI.json -c ./configs/schema-validator/.validaterc -r ./configs/schema-validator/.spectral.yaml


### PR DESCRIPTION
Corrects the file path arguments to the `lint-openapi` command in the schema-validator GitHub action introduced in pull request #18.