### PR TITLE
OB OpenAPI Taxonomy Checker NPM Package Dependency Version Numbers

### DIFF
--- a/.github/workflows/schema-validator.yaml
+++ b/.github/workflows/schema-validator.yaml
@@ -25,9 +25,9 @@ jobs:
         with:
           node-version: '16'
       - name: Install IBM OpenAPI Validator with Spectral
-        run: npm install -g ibm-openapi-validator
+        run: npm install -g ibm-openapi-validator@0.52.1
       - name: Install Typo.js Spellchecker
-        run: npm install typo-js
+        run: npm install typo-js@1.2.1
       - name: Run validator
         working-directory: ./.github
         run: lint-openapi ../Master-OB-OpenAPI.json -c ./configs/schema-validator/.validaterc -r ./configs/schema-validator/.spectral.yaml


### PR DESCRIPTION
The OB OpenAPI taxonomy checker runs the GitHub action `schema-validator.yaml`, which currently uses the NPM packages [IBM OpenAPI Validator](https://www.npmjs.com/package/ibm-openapi-validator) and [Typo.js](https://www.npmjs.com/package/typo-js). When the taxonomy checker was added in pull requests #18, #20, and #21, [IBM OpenAPI Validator 0.52.1](https://github.com/IBM/openapi-validator/releases/tag/ibm-openapi-validator%400.52.1) and [Typo.js 1.2.1](https://www.npmjs.com/package/typo-js/v/1.2.1) were used.

These version numbers are now specified in `schema-validator.yaml` so that the taxonomy checker uses these versions of the NPM packages every time.

Currently in later releases of the IBM OpenAPI Validator, there is an update to its dependencies ([Spectral](https://github.com/stoplightio/spectral) and [Nimma](https://github.com/P0lip/nimma)) that breaks the custom Spectral rules of the taxonomy checker.