### PR TITLE
Implement CEC module listing elements

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -8015,9 +8015,6 @@
               "PowerWarranty": {
                 "$ref": "#/components/schemas/PowerWarranty"
               },
-              "PowerMaximum": {
-                "$ref": "#/components/schemas/PowerMaximum"
-              },
               "VoltageAtMaximumPower": {
                 "$ref": "#/components/schemas/VoltageAtMaximumPower"
               },
@@ -8134,6 +8131,9 @@
               },
               "CECNotes": {
                 "$ref": "#/components/schemas/CECNotes"
+              },
+              "PowerSTC": {
+                "$ref": "#/components/schemas/PowerSTC"
               }
             }
           }
@@ -10819,42 +10819,6 @@
           }
         ]
       },
-      "PowerDCMaxSTC": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TaxonomyElementNumber"
-          },
-          {
-            "type": "object",
-            "description": "Maximum DC power at Standard Test Condition (STC). STC is defined as 1000 W/m2 irradiance, 25C and ASTM G173-03 standard solar spectrum.",
-            "x-ob-item-type": "num:powerItemType",
-            "x-ob-item-type-group": "OBElectricalPower",
-            "x-ob-usage-tips": "",
-            "x-ob-sample-value": {
-              "Value": 300,
-              "Unit": "W"
-            }
-          }
-        ]
-      },
-      "PowerDCMaxPTC": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TaxonomyElementNumber"
-          },
-          {
-            "type": "object",
-            "description": "Maximum DC power at PVUSA Test Condition (PTC). PTC is defined as 1000 W/m2 irradiance, 20C air temperature and 1 m/s wind speed at 10m above ground.",
-            "x-ob-item-type": "num:powerItemType",
-            "x-ob-item-type-group": "OBElectricalPower",
-            "x-ob-usage-tips": "",
-            "x-ob-sample-value": {
-              "Value": 300,
-              "Unit": "W"
-            }
-          }
-        ]
-      },
       "ModuleArea": {
         "allOf": [
           {
@@ -10889,6 +10853,65 @@
             }
           }
         ]
+      },
+      "ModuleRatingCondition": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementString"
+          },
+          {
+            "type": "object",
+            "description": "A condition at which a module electrical rating is determined.",
+            "x-ob-item-type": "ModuleRatingConditionItemType",
+            "x-ob-item-type-group": "",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": {
+              "Value": "STC"
+            }
+          }
+        ]
+      },
+      "PowerSTC": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementNumber"
+          },
+          {
+            "type": "object",
+            "description": "DC power at Standard Test Condition (STC). STC is defined as 1000 W/m2 irradiance, 25C and ASTM G173-03 standard solar spectrum.",
+            "x-ob-item-type": "num:powerItemType",
+            "x-ob-item-type-group": "OBElectricalPower",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": {
+              "Value": 300,
+              "Unit": "W"
+            }
+          }
+        ]
+      },
+      "ModuleElectRating": {
+        "type": "object",
+        "description": "Data describing the module characteristics at a specific rating condition.",
+        "properties": {
+          "PowerDC": {
+            "$ref": "#/components/schemas/PowerDC"
+          },
+          "VoltageOpenCircuit": {
+            "$ref": "#/components/schemas/VoltageOpenCircuit"
+          },
+          "VoltageAtMaximumPower": {
+            "$ref": "#/components/schemas/VoltageAtMaximumPower"
+          },
+          "CurrentShortCircuit": {
+            "$ref": "#/components/schemas/CurrentShortCircuit"
+          },
+          "CurrentAtMaximumPower": {
+            "$ref": "#/components/schemas/CurrentAtMaximumPower"
+          },
+          "ModuleRatingCondition": {
+            "$ref": "#/components/schemas/ModuleRatingCondition"
+          }
+        }
       }
     }
   },
@@ -16154,6 +16177,27 @@
         "BoostBuck": {
           "label": "Boost-Buck",
           "description": "This optimizer is Boost-Buck"
+        }
+      }
+    },
+    "ModuleRatingConditionItemType": {
+      "description": "Conditions at which PV module electrical ratings are made.",
+      "enums": {
+        "STC": {
+          "label": "Standard Test Condition",
+          "description": "1000 W/m2, 25C, ASTM G-173 spectrum"
+        },
+        "PTC": {
+          "label": "PVUSA Test Condition",
+          "description": "1000 W/m2, 20C air temperature, 1 m/s wind speed, air mass of 1.5. "
+        },
+        "NOCT": {
+          "label": "Nominal Operating Cell Temperature",
+          "description": "800 W/m2, 20C air temperature, 1 m/s wind speed, mounting is open for air circulation."
+        },
+        "LIC": {
+          "label": "Low Irradiance Condition",
+          "description": "200 W/m2, 25C module temperature, 0 m/s wind speed and air mass 1.5."
         }
       }
     }

--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -8015,15 +8015,6 @@
               "PowerWarranty": {
                 "$ref": "#/components/schemas/PowerWarranty"
               },
-              "VoltageAtMaximumPower": {
-                "$ref": "#/components/schemas/VoltageAtMaximumPower"
-              },
-              "CurrentAtMaximumPower": {
-                "$ref": "#/components/schemas/CurrentAtMaximumPower"
-              },
-              "CurrentShortCircuit": {
-                "$ref": "#/components/schemas/CurrentShortCircuit"
-              },
               "ModuleEfficiency": {
                 "$ref": "#/components/schemas/ModuleEfficiency"
               },
@@ -8134,6 +8125,9 @@
               },
               "PowerSTC": {
                 "$ref": "#/components/schemas/PowerSTC"
+              },
+              "ModuleElectRatings": {
+                "$ref": "#/components/schemas/ModuleElectRatings"
               }
             }
           }
@@ -10911,6 +10905,12 @@
           "ModuleRatingCondition": {
             "$ref": "#/components/schemas/ModuleRatingCondition"
           }
+        }
+      },
+      "ModuleElectRatings": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ModuleElectRating"
         }
       }
     }

--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -7702,6 +7702,40 @@
           }
         ]
       },
+      "TemperatureCoefficientMaxPowerVoltage": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementNumber"
+          },
+          {
+            "type": "object",
+            "description": "The temperature coefficient of voltage at maximum power.",
+            "x-ob-item-type": "tempCoefficientItemType",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": {
+              "Value": -0.304
+            },
+            "x-ob-item-type-group": ""
+          }
+        ]
+      },
+      "TemperatureCoefficientMaxPowerCurrent": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementNumber"
+          },
+          {
+            "type": "object",
+            "description": "The temperature coefficient of current at maximum power.",
+            "x-ob-item-type": "tempCoefficientItemType",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": {
+              "Value": 0.05
+            },
+            "x-ob-item-type-group": ""
+          }
+        ]
+      },
       "VoltageMaximumSystem": {
         "allOf": [
           {
@@ -7733,23 +7767,6 @@
             "x-ob-sample-value": {
               "Unit": "Ampere",
               "Value": 20
-            },
-            "x-ob-item-type-group": ""
-          }
-        ]
-      },
-      "CellType": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TaxonomyElementString"
-          },
-          {
-            "type": "object",
-            "description": "The cell type for a solar module",
-            "x-ob-item-type": "cellTechnologyItemType",
-            "x-ob-usage-tips": "Used for large group categorizations",
-            "x-ob-sample-value": {
-              "Value": "monoSi"
             },
             "x-ob-item-type-group": ""
           }
@@ -8114,6 +8131,9 @@
               },
               "Warranties": {
                 "$ref": "#/components/schemas/Warranties"
+              },
+              "CECNotes": {
+                "$ref": "#/components/schemas/CECNotes"
               }
             }
           }
@@ -8123,9 +8143,6 @@
         "type": "object",
         "description": "A subcomponent of a ProdModule",
         "properties": {
-          "CellType": {
-            "$ref": "#/components/schemas/CellType"
-          },
           "Description": {
             "$ref": "#/components/schemas/Description"
           },
@@ -10798,6 +10815,77 @@
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
               "Value": "Data Source"
+            }
+          }
+        ]
+      },
+      "PowerDCMaxSTC": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementNumber"
+          },
+          {
+            "type": "object",
+            "description": "Maximum DC power at Standard Test Condition (STC). STC is defined as 1000 W/m2 irradiance, 25C and ASTM G173-03 standard solar spectrum.",
+            "x-ob-item-type": "num:powerItemType",
+            "x-ob-item-type-group": "OBElectricalPower",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": {
+              "Value": 300,
+              "Unit": "W"
+            }
+          }
+        ]
+      },
+      "PowerDCMaxPTC": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementNumber"
+          },
+          {
+            "type": "object",
+            "description": "Maximum DC power at PVUSA Test Condition (PTC). PTC is defined as 1000 W/m2 irradiance, 20C air temperature and 1 m/s wind speed at 10m above ground.",
+            "x-ob-item-type": "num:powerItemType",
+            "x-ob-item-type-group": "OBElectricalPower",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": {
+              "Value": 300,
+              "Unit": "W"
+            }
+          }
+        ]
+      },
+      "ModuleArea": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementNumber"
+          },
+          {
+            "type": "object",
+            "description": "The area of a PV module inside the frame. Equal to total module area for a frameless module.",
+            "x-ob-item-type": "num:areaItemType",
+            "x-ob-item-type-group": "",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": {
+              "Value": 1.5,
+              "Unit": "sqm"
+            }
+          }
+        ]
+      },
+      "IsBIPV": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaxonomyElementBoolean"
+          },
+          {
+            "type": "object",
+            "description": "True if the PV module is intended for a building-integrated PV system.",
+            "x-ob-item-type": "stdi:booleanItemType",
+            "x-ob-item-type-group": "",
+            "x-ob-usage-tips": "",
+            "x-ob-sample-value": {
+              "Value": true
             }
           }
         ]

--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -8128,6 +8128,15 @@
               },
               "ModuleElectRatings": {
                 "$ref": "#/components/schemas/ModuleElectRatings"
+              },
+              "IsBIPV": {
+                "$ref": "#/components/schemas/IsBIPV"
+              },
+              "TemperatureCoefficientMaxPowerCurrent": {
+                "$ref": "#/components/schemas/TemperatureCoefficientMaxPowerCurrent"
+              },
+              "TemperatureCoefficientMaxPowerVoltage": {
+                "$ref": "#/components/schemas/TemperatureCoefficientMaxPowerVoltage"
               }
             }
           }

--- a/docs/whatsnew/2202.1.0.rst
+++ b/docs/whatsnew/2202.1.0.rst
@@ -3,26 +3,33 @@
 2202.1.0
 --------
 
+Element changes
+~~~~~~~~~~~~~~~
+* Add ContractID, ProjectID, PortfolioID, ProjectName, PorfolioName, Projects, Sites  (:pull:`35`)
+* Add FirmwareVersion, CertificationDate, Checksum, AppliedDate, EfficiencyCECWtdVoltageMax, EfficiencyCECWtdVoltageMin, EfficiencyCECWtdVoltageNom, NightTare, IsHybrid, HasMeter, CECNotes, Identifier, SourceName (:pull:`51`)
+* Add OptimizerType, CompatibleWith, AllowsString, IsVocReducing, IsSelectiveOptimization, GeoRegion, (:pull:`50`)
+* Add TemperatureCoefficientMaxPowerVoltage, TemperatureCoefficientMaxPowerCurrent, PowerSTC, ModuleArea, IsBIPV, ModuleRatingCondition (:pull:`60`)
+* Remove CellType, redundant with CellTechnologyType (:pull:`60`)
 
-Elements added
+Object changes
 ~~~~~~~~~~~~~~
-* Adds ContractID, ProjectID, PortfolioID, ProjectName, PorfolioName, Projects, Sites  (:pull:`35`)
-* Adds FirmwareVersion, CertificationDate, Checksum, AppliedDate, EfficiencyCECWtdVoltageMax, EfficiencyCECWtdVoltageMin, EfficiencyCECWtdVoltageNom, NightTare, IsHybrid, HasMeter, CECNotes
-  Identifier, SourceName (:pull:`51`)
-* Adds OptimizerType, CompatibleWith, AllowsString, IsVocReducing, IsSelectiveOptimization, GeoRegion, (:pull:`50`)
+* Add Portfolio, Project (:pull:`35`)
+* Add Firmware, FirmwareVersions, AlternativeIdentifier, AlternativeIdentifiers (:pull:`51`)
+* Add ModuleElectRating (:pull:`60`)
+* Add to ProdModule: TemperatureCoefficientMaxPowerVoltage, TemperatureCoefficientMaxPowerCurrent, PowerSTC, ModuleArea, IsBIPV, ModuleRatingCondition, ModuleElectRatings (:pull:`60`)
+* Remove from ProdModule: CurrentAtMaximumPower, CurrentShortCircuit, VoltageAtMaximumPower. These elements are replaced by ModuleElectRatings. (:pull:`60`)
 
-Objects added
+Array changes
 ~~~~~~~~~~~~~
-* Adds Portfolio, Project Objects (:pull:`35`)
-* Adds Firmware, FirmwareVersions
-  AlternativeIdentifier, AlternativeIdentifiers (:pull:`51`)
+* Add ModuleElectRatings (:pull:`60`)
 
-Units added
-~~~~~~~~~~~
-* Adds AccelerationItemType (:pull:`47`)
-* Adds OptimizerTypeItemType (:pull:`50`)
-* Removes solar-types:optimizerTypeItemType(:pull:`50`)
-* Adds "UL1973" and "JA12" to CertificationTypeProductItemType (:pull:`58`) 
+Unit changes
+~~~~~~~~~~~~
+* Add AccelerationItemType (:pull:`47`)
+* Add OptimizerTypeItemType (:pull:`50`)
+* Add Values "UL1973" and "JA12" to CertificationTypeProductItemType (:pull:`58`) 
+* Add ModuleRatingConditionItemType (:pull:`60`)
+* Remove solar-types:optimizerTypeItemType(:pull:`50`)
 
 Bug fixes
 ~~~~~~~~~


### PR DESCRIPTION
Adds elements:
* TemperatureCoefficientMaxPowerVoltage
* TemperatureCoefficientMaxPowerCurrent
* PowerSTC
* ModuleArea
* IsBIPV
* ModuleRatingCondition

Adds objects:
* ModuleElectRating

Adds arrays:
* ModuleElectRatings

Deletes element:
* CellType, redundant with CellTechnologyType

Add ItemTypes:
* ModuleRatingConditionItemType

Adds PowerSTC, ModuleElectRatings, TemperatureCoefficientMaxPowerVoltage, TemperatureCoefficientMaxPowerCurrent, ModuleArea, IsBIPV to ProdModule

Removes CurrentAtMaximumPower, CurrentShortCircuit, VoltageAtMaximumPower from ProdModule. These elements are replaced by ProdModule.ModuleElectRating object.

Adds CECNotes to ProdModule

