### PR TITLE
Generic Scope adjustments for issue 121, 118

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -25,11 +25,11 @@
           "EnergyModelOutput": {
             "$ref": "#/components/schemas/EnergyModelOutput"
           },
-          "EnergyModelScope": {
-            "$ref": "#/components/schemas/EnergyModelScope"
-          },
           "ModelRunDate": {
             "$ref": "#/components/schemas/ModelRunDate"
+          },
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         },
         "x-ob-usage-tips": ""
@@ -1654,8 +1654,8 @@
           "Comments": {
             "$ref": "#/components/schemas/Comments"
           },
-          "TaskScope": {
-            "$ref": "#/components/schemas/TaskScope"
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         },
         "x-ob-usage-tips": ""
@@ -1879,28 +1879,6 @@
             "x-ob-item-type-group": ""
           }
         ]
-      },
-      "BillOfMaterials": {
-        "type": "object",
-        "description": "Bill of Materials for a System",
-        "properties": {
-          "ProdLineItems": {
-            "$ref": "#/components/schemas/ProdLineItems"
-          },
-          "BillOfMaterialsStatus": {
-            "$ref": "#/components/schemas/BillOfMaterialsStatus"
-          },
-          "FileFolderURL": {
-            "$ref": "#/components/schemas/FileFolderURL"
-          },
-          "Description": {
-            "$ref": "#/components/schemas/Description"
-          },
-          "BOMScope": {
-            "$ref": "#/components/schemas/BOMScope"
-          }
-        },
-        "x-ob-usage-tips": ""
       },
       "ProdLineItems": {
         "type": "array",
@@ -2666,6 +2644,9 @@
           },
           "Answers": {
             "$ref": "#/components/schemas/Answers"
+          },
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         }
       },
@@ -4207,8 +4188,8 @@
           "BillOfServicesStatus": {
             "$ref": "#/components/schemas/BillOfServicesStatus"
           },
-          "BOSScope": {
-            "$ref": "#/components/schemas/BOSScope"
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         }
       },
@@ -6613,8 +6594,8 @@
           "Tags": {
             "$ref": "#/components/schemas/Tags"
           },
-          "CommentScope": {
-            "$ref": "#/components/schemas/CommentScope"
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         }
       },
@@ -10618,8 +10599,8 @@
           "TempModuleArray": {
             "$ref": "#/components/schemas/TempModuleArray"
           },
-          "ForecastScope": {
-            "$ref": "#/components/schemas/ForecastScope"
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         }
       },
@@ -10934,30 +10915,6 @@
           }
         ]
       },
-      "BOMScope": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Scope"
-          },
-          {
-            "type": "object",
-            "description": "Scope of the BillOfMaterials object.",
-            "properties": {}
-          }
-        ]
-      },
-      "EnergyModelScope": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Scope"
-          },
-          {
-            "type": "object",
-            "description": "Scope of an energy model",
-            "properties": {}
-          }
-        ]
-      },
       "ModelRunDate": {
         "allOf": [
           {
@@ -11014,42 +10971,6 @@
         "items": {
           "$ref": "#/components/schemas/EnergyModel"
         }
-      },
-      "BOSScope": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Scope"
-          },
-          {
-            "type": "object",
-            "description": "Scope of the BillOfServices object.",
-            "properties": {}
-          }
-        ]
-      },
-      "CommentScope": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Scope"
-          },
-          {
-            "type": "object",
-            "description": "Scope of Comment object.",
-            "properties": {}
-          }
-        ]
-      },
-      "TaskScope": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Scope"
-          },
-          {
-            "type": "object",
-            "description": "Scope of the Task object.",
-            "properties": {}
-          }
-        ]
       },
       "PerClaimAmount": {
         "allOf": [
@@ -11152,9 +11073,6 @@
           "InsurancePolicyID": {
             "$ref": "#/components/schemas/InsurancePolicyID"
           },
-          "InsurancePolicyScope": {
-            "$ref": "#/components/schemas/InsurancePolicyScope"
-          },
           "FileFolderURL": {
             "$ref": "#/components/schemas/FileFolderURL"
           },
@@ -11175,20 +11093,11 @@
           },
           "Comments": {
             "$ref": "#/components/schemas/Comments"
+          },
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         }
-      },
-      "InsurancePolicyScope": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Scope"
-          },
-          {
-            "type": "object",
-            "description": "Scope of the InsurancePolicy object.",
-            "properties": {}
-          }
-        ]
       },
       "Signatory": {
         "allOf": [
@@ -11288,18 +11197,6 @@
           }
         ]
       },
-      "ForecastScope": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Scope"
-          },
-          {
-            "type": "object",
-            "description": "The scope of a forecast object, an instance of base class Scope",
-            "properties": {}
-          }
-        ]
-      },
       "Production": {
         "type": "object",
         "description": "A collection of electrical and related measurements with a common scope.",
@@ -11309,9 +11206,6 @@
           },
           "IrradGlobalHorizMeas": {
             "$ref": "#/components/schemas/IrradGlobalHorizMeas"
-          },
-          "MeasScope": {
-            "$ref": "#/components/schemas/MeasScope"
           },
           "PowerACMeas": {
             "$ref": "#/components/schemas/PowerACMeas"
@@ -11327,25 +11221,38 @@
           },
           "Comments": {
             "$ref": "#/components/schemas/Comments"
+          },
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         }
       },
-      "MeasScope": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Scope"
+      "BillOfMaterials": {
+        "type": "object",
+        "description": "Bill of Materials for a System",
+        "properties": {
+          "ProdLineItems": {
+            "$ref": "#/components/schemas/ProdLineItems"
           },
-          {
-            "type": "object",
-            "description": "The scope of a set of measurements",
-            "properties": {}
+          "BillOfMaterialsStatus": {
+            "$ref": "#/components/schemas/BillOfMaterialsStatus"
+          },
+          "FileFolderURL": {
+            "$ref": "#/components/schemas/FileFolderURL"
+          },
+          "Description": {
+            "$ref": "#/components/schemas/Description"
+          },
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
-        ]
+        },
+        "x-ob-usage-tips": ""
       },
       "IrradPlaneOfArrayMeas": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/MeasScope"
+            "$ref": "#/components/schemas/Scope"
           },
           {
             "type": "object",

--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -10544,21 +10544,6 @@
           "$ref": "#/components/schemas/TempModule"
         }
       },
-      "ForecastScopeID": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TaxonomyElementString"
-          },
-          {
-            "type": "object",
-            "description": "An identifier for the device, system, portfolio, or region where a forecast applied.",
-            "x-ob-item-type": "StringItemType",
-            "x-ob-item-type-group": "",
-            "x-ob-usage-tips": "",
-            "x-ob-sample-value": {}
-          }
-        ]
-      },
       "IrradPlaneOfArrayArray": {
         "type": "array",
         "items": {
@@ -10603,21 +10588,6 @@
             "$ref": "#/components/schemas/Scope"
           }
         }
-      },
-      "ForecastScopeType": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/TaxonomyElementString"
-          },
-          {
-            "type": "object",
-            "description": "The scope where a forecast applies.",
-            "x-ob-item-type": "ForecastScopeTypeItemType",
-            "x-ob-item-type-group": "",
-            "x-ob-usage-tips": "",
-            "x-ob-sample-value": {}
-          }
-        ]
       },
       "Scope": {
         "type": "object",
@@ -10676,9 +10646,6 @@
         "properties": {
           "Scope": {
             "$ref": "#/components/schemas/Scope"
-          },
-          "Comment": {
-            "$ref": "#/components/schemas/Comment"
           },
           "Description": {
             "$ref": "#/components/schemas/Description"
@@ -11252,7 +11219,7 @@
       "IrradPlaneOfArrayMeas": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/Scope"
+            "$ref": "#/components/schemas/Measurement"
           },
           {
             "type": "object",

--- a/docs/whatsnew/2209.1.0.rst
+++ b/docs/whatsnew/2209.1.0.rst
@@ -14,13 +14,9 @@ Object changes
  * Signatory and Preparer now inherit from Entity rather than use Entity directly (:pull:`106`)
  * Removes EnergyMeasurement, EnergyMeasurements. Replaced by Production. (:pull:`117`)
  * Adds IrradPlaneOfArrayMeas. Remakes MeasScope to inherit from Scope. (:pull:`117`) 
- 
-
-Unit changes
-~~~~~~~~~~~~
-
-Object changes
-~~~~~~~~~~~~~~
+ * Removes and deletes Member : BOMScope, BOSScope, CommentScope, MeasScope, ForecastScope, MeasScope, InsurancePolicyScope, TaskScope (:pull:`127`)
+ * Adds Generic Scope member to: BillOfMaterials, BillOfServices, Checklist, Comment, Task, EnergyModel, Forecast, InsurancePolicy, Measurement, Production (:pull:`127`)
+ * Changes IrradPlaneOfArrayMeas inheritance from MeasScope to generic Scope (:pull:`127`)
 
 Unit changes
 ~~~~~~~~~~~~

--- a/docs/whatsnew/2209.1.0.rst
+++ b/docs/whatsnew/2209.1.0.rst
@@ -17,6 +17,8 @@ Object changes
  * Removes and deletes Member : BOMScope, BOSScope, CommentScope, MeasScope, ForecastScope, MeasScope, InsurancePolicyScope, TaskScope (:pull:`127`)
  * Adds Generic Scope member to: BillOfMaterials, BillOfServices, Checklist, Comment, Task, EnergyModel, Forecast, InsurancePolicy, Measurement, Production (:pull:`127`)
  * Changes IrradPlaneOfArrayMeas inheritance from MeasScope to generic Scope (:pull:`127`)
+ * Removes Comment from Measurement Object (:pull:`127`)
+ * Removes  ForecastScopeID,  ForecastScopeType from Taxonomy (:pull:`127`)
 
 Unit changes
 ~~~~~~~~~~~~


### PR DESCRIPTION
IrradPlaneOfArrayMeas — Inherited MeasScope rather than has the member added— Changed to inherit generic Scope 


Removes and deletes Member : BOMScope, BOSScope, CommentScope, MeasScope, ForecastScope, MeasScope, InsurancePolicyScope, TaskScope


Adds Generic Scope member to: BillOfMaterials, BillOfServices, Checklist (Closes #121), Comment, Task, EnergyModel, Forecast, InsurancePolicy, Measurement, Production 

Closes #118 