### PR TITLE
Fixing taxonomy checker error about OB elements.

### DIFF
--- a/.github/configs/schema-validator/.spectral.yaml
+++ b/.github/configs/schema-validator/.spectral.yaml
@@ -14,7 +14,7 @@ rules:
   property-case-convention: off
   property-description: off
   property-inconsistent-name-and-type: off
-  
+
   element-valid-item-type:
     message: 'Item type does not exist: {{error}}'
     given: $.components.schemas[*].allOf[1][x-ob-item-type]
@@ -23,7 +23,7 @@ rules:
       function: validateXOBFields
       functionOptions:
         objectPath: x-ob-item-types
-  
+
   element-valid-item-type-group:
     message: 'Item type group does not exist: {{error}}'
     given: $.components.schemas[*].allOf[1][x-ob-item-type-group]
@@ -39,7 +39,7 @@ rules:
     severity: error
     then:
       function: refPathExists
-  
+
   item-type-group-valid-entries:
     description: The enums or units in the item type group exist in the item type definition.
     message: '{{error}}'
@@ -47,7 +47,7 @@ rules:
     severity: error
     then:
       function: validateItemTypeGroupEntries
-  
+
   element-valid-sample-value:
     description: >-
       Checks the following items about sample value:
@@ -63,7 +63,7 @@ rules:
     message: '{{error}}'
     # Give entire 'allOf' array of an element definition
     # Spectral resolves all $ref's, so allOf[0].properties.Value exists
-    given: $.components.schemas[*][?(@property === 'allOf' && @[0].properties.Value)]
+    given: $.components.schemas[*][?(@property === 'allOf' && @[0].properties && @[0].properties.Value)]
     severity: error
     then:
       function: validateXOBSampleValue
@@ -82,11 +82,11 @@ rules:
       For OB item types without enums or units, all schema definitions that use these
       OB item types should have the same OpenAPI type.
     message: '{{error}}'
-    given: $.components.schemas[*][?(@property === 'allOf' && @[0].properties.Value)]
+    given: $.components.schemas[*][?(@property === 'allOf' && @[0].properties && @[0].properties.Value)]
     severity: error
     then:
       function: validateItemTypeAgainstElementType
-  
+
   no-special-characters:
     description: Name must only contain characters in 0-9, A-Z, a-z, and _ (underscore).
     type: style

--- a/.github/configs/schema-validator/ibm-oas-wrapper-check-components.js
+++ b/.github/configs/schema-validator/ibm-oas-wrapper-check-components.js
@@ -1,6 +1,6 @@
 /**
  * Wrapper of IBM OAS (@ibm-cloud/openapi-ruleset) to let its schema rules check schema definitions in OpenAPI components.
- * 
+ *
  * The code here (https://github.com/IBM/openapi-validator/blob/098138ab7387a18f1a600ff33da9430ed1c4461f/packages/ruleset/src/collections/index.js#L11)
  * shows that schema rules of IBM OAS only check schema definitions that are used in an OpenAPI path, not those only defined in OpenAPI components.
  */


### PR DESCRIPTION
Closes #120.

The taxonomy checker has validation rules that apply only to OB elements, so these rules filter the taxonomy definitions to find the OB elements. Since the taxonomy checker resolves all `$ref` pointers before running the filters, this filter cannot check the `$ref` pointer string for containing `TaxonomyElement`. Instead, this filter decides that a definition is an OB element if `allOf` exists, and `allOf[0].properties.Value` exists.

This implementation crashes when `allOf[0].properties` does not exist, and this happens when there is a chain of inheritance of length two or more. #117 included the chain of inheritance `Scope -> MeasScope -> IrradPlaneOfArrayMeas` where `superclass -> subclass`. Here `IrradPlaneOfArrayMeas.allOf[0]` equals `MeasScope.allOf` which is an array so `IrradPlaneOfArrayMeas.allOf[0].properties` does not exist. To avoid crashing in this case, the filter now checks that `allOf` exists, `allOf[0].properties` exists, and finally that `allOf[0].properties.Value` exists.