### PR TITLE
Rework EnergyConsumption and EnergyUsage

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -1656,11 +1656,11 @@
         "type": "object",
         "description": "The energy consumption history of a site",
         "properties": {
-          "SiteID": {
-            "$ref": "#/components/schemas/SiteID"
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           },
-          "EnergyUsages": {
-            "$ref": "#/components/schemas/EnergyUsages"
+          "EnergyACArray": {
+            "$ref": "#/components/schemas/EnergyACArray"
           }
         },
         "x-ob-usage-tips": ""
@@ -10378,10 +10378,7 @@
         ]
       },
       "EnergyACArray": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/EnergyAC"
-        }
+        "description": "An array of EnergyAC, which is energy (AC) measured for a period of time."
       },
       "ForecastName": {
         "allOf": [

--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -1646,8 +1646,11 @@
         "type": "object",
         "description": "A value of energy consumed in one time period",
         "properties": {
-          "EnergyAC": {
-            "$ref": "#/components/schemas/EnergyAC"
+          "EnergyACArray": {
+            "$ref": "#/components/schemas/EnergyACArray"
+          },
+          "Scope": {
+            "$ref": "#/components/schemas/Scope"
           }
         },
         "x-ob-usage-tips": ""
@@ -10378,7 +10381,10 @@
         ]
       },
       "EnergyACArray": {
-        "description": "An array of EnergyAC, which is energy (AC) measured for a period of time."
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/EnergyAC"
+        }
       },
       "ForecastName": {
         "allOf": [

--- a/docs/whatsnew/2209.1.0.rst
+++ b/docs/whatsnew/2209.1.0.rst
@@ -41,6 +41,9 @@ Object changes
  * Adds PerformanceIndex and PerformanceIndexes (:pull:`173`)
  * Adds Availability, Availabilities, AvailabilityReport, UpTime, UpTimes, DownTime, DownTimes (:pull:`187`)
  * Adds ModuleArea to ProdModule (:pull:`189`)
+ * In EnergyConsumption, SiteID is replaced by Scope, and EnergyAC is replaced by EnergyACArray (:pull:`196`)
+ * In EnergyUsage, Scope is added, and EnergyAC is replaced by EnergyACArray (:pull:`196`)
+ 
 
 Unit changes
 ~~~~~~~~~~~~


### PR DESCRIPTION
Closes #129 

In EnergyConsumption, replace SiteID with Scope, EnergyUsages with EnergyACArray

In EnergyUsage, add Scope and EnergyACArray, and remove EnergyAC.

The intent is that EnergyConsumption reports self-consumption, where as EnergyUsage is more general.