### PR TITLE
Taxonomy Checker Updates

### DIFF
--- a/.github/configs/schema-validator/.spectral.yaml
+++ b/.github/configs/schema-validator/.spectral.yaml
@@ -1,19 +1,21 @@
 extends: 'ibm-oas-wrapper-check-components.js'
 functions: [spellcheckSubstrings,
+            noSuperclassFieldShadowing,
             validateXOBFields,
             refPathExists,
             validateItemTypeGroupEntries,
             validateXOBSampleValue,
             validateItemTypeAgainstElementType]
 rules:
-  enum-case-convention: off
-  major-version-in-path: off
+  ibm-array-attributes: off
+  ibm-enum-casing-convention: off
+  ibm-major-version-in-path: off
   openapi-tags: off
   oas3-api-servers: off
   oas3-unused-component: off
-  property-case-convention: off
-  property-description: off
-  property-inconsistent-name-and-type: off
+  ibm-property-casing-convention: off
+  ibm-property-description: off
+  ibm-property-consistent-name-and-type: off
 
   element-valid-item-type:
     message: 'Item type does not exist: {{error}}'
@@ -86,6 +88,14 @@ rules:
     severity: error
     then:
       function: validateItemTypeAgainstElementType
+
+  no-superclass-field-shadowing:
+    description: Check that OB Objects do not define fields whose names conflict with the fields of their superclass.
+    message: '{{error}}'
+    given: $.components.schemas[*][?(@property === 'allOf' && !(@[0].properties && @[0].properties.Value))]
+    severity: error
+    then:
+      function: noSuperclassFieldShadowing
 
   no-special-characters:
     description: Name must only contain characters in 0-9, A-Z, a-z, and _ (underscore).

--- a/.github/configs/schema-validator/.spectral.yaml
+++ b/.github/configs/schema-validator/.spectral.yaml
@@ -138,7 +138,7 @@ rules:
     then:
       function: spellcheckSubstrings
       functionOptions:
-        substringMatch: '[0-9]+|[A-Z][a-z]+|[A-Z]+(?![a-z])'
+        substringMatch: '[0-9]+|[A-Z][a-z]+|[A-Z]+s|[A-Z]+(?![a-z])'
         dictionaries:
           - name: en_US
             path: node_modules/typo-js/dictionaries

--- a/.github/configs/schema-validator/.spectral.yaml
+++ b/.github/configs/schema-validator/.spectral.yaml
@@ -58,9 +58,9 @@ rules:
       - Value has the correct OpenAPI type
       - If the schema definition OB item type defines enums or units:
         - When enums are defined, Value is an enum of the OB item type.
-          - If the schema definition has an OB item type group, Value is an enum of the item type group.
-        - When units are defined, Unit is a unit of the OB item type.
-          - If the schema definition has an OB item type group, Unit is a unit of the item type group.
+          - If the schema definition has an OB item type group, Value is in the item type group.
+        - When units are defined, sample value has a Unit defined by the OB item type.
+          - If the schema definition has an OB item type group, Unit is in the item type group.
       - Additional validation rules for each primitive can be added to validateXOBSampleValue.
     message: '{{error}}'
     # Give entire 'allOf' array of an element definition

--- a/.github/configs/schema-validator/OB-dictionaries/OB-words/OB-words.dic
+++ b/.github/configs/schema-validator/OB-dictionaries/OB-words/OB-words.dic
@@ -1,47 +1,52 @@
 0
 ACH//Automated Clearing House
-Addr//Address
 AGM//Absorbent Glass Mat
 AHJ//Authority Having Jurisdiction
 AHJID//Authority Having Jurisdiction Identifier
+Addr//Address
 Amb//Ambient
 App//Application
 ASCE//American Society of Civil Engineers
 ASHRAE//American Society of Heating, Refrigerating and Air-Conditioning
 ASTME//American Society of Tool and Manufacturing Engineers
 AWG//American Wire Gauge
+BIPV//Building-Integrated Photovoltaics
 Backsheet
 Bifacial
-BIPV//Building-Integrated Photovoltaics
+Bool
 Boreal
 Busbar
 CEC//California Energy Commission
 CIGS//Copper Indium Gallium Diselenide Selenium
+CPV//Concentrator Photovoltaic
+CSIP//Common Smart Inverter Profile
 Coeff//Coefficient
 Cond//Condition
 Counterparty
-CPV//Concentrator Photovoltaic
-CSIP//Common Smart Inverter Profile
 Datasheet
 Derate
 Diene
+ESS//Energy Storage System
 EWG//Environmental Working Group
 Facil//Facilitator
-ProForma
 Frameless
-Gauge
-Geocoding
+Forecasted
 GIS//Geographic Information System
 GML//Generalized Markup Language
 GPS//Global Positioning System
+Gauge
+Geocoding
+HJT//Heterojunction Technology
+HOA//Homeowners Association
 Hemiboreal
 Heterojunction
-HOA//Homeowners Association
+Horiz//Horizontal
 IBC//International Building Code
 IEC//International Electric Code
+IECTS//International Electrotechnical Commission Technical Specification
 IFC//International Fire Code
-Insolation
 IRC//International Residential Code
+Insolation
 Irrad//Irradiance
 Irradiance
 JA//Joint Appendix
@@ -50,60 +55,65 @@ KML//Keyhole Markup Language
 Koppen
 LIC//Low Irradiance Condition
 LiPoly
-Maint//Maintenance
 MCER//Risk-Targeted Maximum Considered Earthquake
+MOR//Monthly Operating Report
+MPPT//Maximum Power Point Tracker
+MPPTs//Maximum Power Point Trackers
+Maint//Maintenance
+Majeure
 Megathermal
 Mesothermal
 Meth//Method
 Microthermal
 Modbus
-MOR//Monthly Operating Report
-MPPT//Maximum Power Point Tracker
-MPPTs//Maximum Power Point Trackers
 Nanogrid
 NEC//National Electric Code
 NiMH//Nickel Metal Hydride
 NOCT//Nominal Operating Cell Temperature
+NRTL//Nationally Recognized Testing Laboratory
 Nom//Nominal
 Noncurrent
 Noninterest
 Nonposting
-NRTL//Nationally Recognized Testing Laboratory
 Num//Number
 Obligee
 Offline
 Online
+PPA//Power Purchase Agreement
+PSA//Power Sale Agreement
+PTC//PVUSA Test Condition
+PV//Photovoltaic
+PVUSA//Photovoltaics for Utility Scale Applications
 Perf//Performance
 Polyolefin
 PolySi
-PPA//Power Purchase Agreement
 Pre
-PSA//Power Sale Agreement
-PTC//PVUSA Test Condition
+ProForma
 Purch//Purchase
-PV//Photovoltaic
-PVUSA//Photovoltaics for Utility Scale Applications
 QF//Qualifying Facility
 REbusDCNanogrid
 Reqrmnts//Requirements
 Rpt//Reporting
 Rtg//Rating
+SAEJ//Society of Automotive Engineers J
 SBS//Styrene-Butadiene-Styrene
-Shapefile
+SPEOM//SolarPower Europe Operations and Maintenance
 SPV//Special Purpose Vehicle
 STC//Standard Test Condition
+Shapefile
 Sublimits
 Subpanel
 TCPIP//Transmission Control Protocol/Internet Protocol
-Terpolymer
 TFSI//Thin Film Silicon
 THWN//Thermoplastic Heat and Water Resistant
+Terpolymer
 Transformerless
-Unbilled
+UTF//Unicode Transformation Format
 UUID//Universally Unique Identifier
+Unbilled
 Voc//Open-Circuit Voltage
-Warr//Warranty
 WIFI//Wireless Fidelity
+Warr//Warranty
 Workmans
 Wtd//Weighted
 Zigbee

--- a/.github/configs/schema-validator/functions/noSuperclassFieldShadowing.js
+++ b/.github/configs/schema-validator/functions/noSuperclassFieldShadowing.js
@@ -1,0 +1,19 @@
+export default (input, options, context) => {
+    let superclassFields = new Set(Object.keys(getSuperclassProperties(input[0])));
+    let subclassFields = Object.keys(input[1].properties);
+    let shadowedFields = subclassFields.filter(p => superclassFields.has(p)).sort();
+    if (shadowedFields.length > 0) {
+        return [{ message: `OB Object defines fields that conflict with fields defined by its superclass: ${shadowedFields.join(', ')}` }];
+    }
+}
+
+function getSuperclassProperties(defn) {
+    if (defn.properties) {
+        return defn.properties;
+    }
+    let properties = defn.allOf[1].properties;
+    if (Object.keys(properties).length > 0) {
+        return properties;
+    }
+    return getSuperclassProperties(defn.allOf[0]);
+}

--- a/.github/configs/schema-validator/functions/validateXOBSampleValue.js
+++ b/.github/configs/schema-validator/functions/validateXOBSampleValue.js
@@ -92,22 +92,28 @@ function validateUnit(input, taxonomy, addResult) {
   let sampleValue = getSampleValue(input);
   let itemType = getItemType(input);
   let sampleValueUnit = sampleValue[primitive];
-  if (itemType && primitive in sampleValue) {
+  if (itemType) {
     let itemTypeDef = taxonomy['x-ob-item-types'][itemType];
     if (!itemTypeDef) {
       // ignore if item type does not exist, this is checked separately
       return;
     }
     let itemTypeUnits = itemTypeDef['units'];
-    if (!itemTypeUnits) {
-      addResult(`Cannot define 'Unit' because the item type '${itemType}' does not define units.`);
+    if (itemTypeUnits) {
+      if (primitive in sampleValue) {
+        let itemTypeGroup = getItemTypeGroup(input);
+        let itemTypeGroupDef = taxonomy['x-ob-item-type-groups'][itemTypeGroup];
+        if (!itemTypeUnits[sampleValueUnit]) {
+          addResult(`The item type '${itemType}' does not define the unit '${sampleValueUnit}'.`);
+        } else if (itemTypeGroupDef && !itemTypeGroupDef.group.includes(sampleValueUnit)) {
+          addResult(`The item type group '${itemTypeGroup}' does not define the unit '${sampleValueUnit}'.`)
+        }
+      } else {
+        addResult(`Must define 'Unit' because the item type '${itemType}' defines units.`);
+      }
     } else {
-      let itemTypeGroup = getItemTypeGroup(input);
-      let itemTypeGroupDef = taxonomy['x-ob-item-type-groups'][itemTypeGroup];
-      if (!itemTypeUnits[sampleValueUnit]) {
-        addResult(`The item type '${itemType}' does not define the unit '${sampleValueUnit}'.`);
-      } else if (itemTypeGroupDef && !itemTypeGroupDef.group.includes(sampleValueUnit)) {
-        addResult(`The item type group '${itemTypeGroup}' does not define the unit '${sampleValueUnit}'.`)
+      if (primitive in sampleValue) {
+        addResult(`Cannot define 'Unit' because the item type '${itemType}' does not define units.`);
       }
     }
   }

--- a/.github/configs/schema-validator/functions/validateXOBSampleValue.js
+++ b/.github/configs/schema-validator/functions/validateXOBSampleValue.js
@@ -15,8 +15,10 @@ export default (input, options, context) => {
   let sampleValue = getSampleValue(input);
   if (!isObject(sampleValue)) {
     addResult('Sample value must be an object.');
-  } else if (options.requireAtLeastOneField && (!isObject(sampleValue) || Object.keys(sampleValue) === 0)) {
+  } else if (options.requireAtLeastOneField && (!isObject(sampleValue) || Object.keys(sampleValue).length === 0)) {
     addResult('Sample value must have defined primitive fields.');
+  } else if (Object.keys(sampleValue).length === 0) {
+    return; // do not validate an empty object
   } else if (!Object.keys(sampleValue).every(k => primitiveValidators[k])) {
     let extraKeys = Object.keys(sampleValue).filter(k => !primitiveValidators[k]);
     addResult(`These fields are not valid primitives: ${extraKeys.join(', ')}`);

--- a/.github/configs/schema-validator/ibm-oas-wrapper-check-components.js
+++ b/.github/configs/schema-validator/ibm-oas-wrapper-check-components.js
@@ -5,7 +5,7 @@
  * shows that schema rules of IBM OAS only check schema definitions that are used in an OpenAPI path, not those only defined in OpenAPI components.
  */
 const IBMOAS = require('@ibm-cloud/openapi-ruleset');
-const { schemas: locationsWhereSchemaCanBeUsed } = require('@ibm-cloud/openapi-ruleset/src/collections/index.js');
+const { schemas: locationsWhereSchemaCanBeUsed } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections/index.js');
 Object.values(IBMOAS.rules).forEach(ruleDef => {
   // A schema rule is identified by what JSONPaths it is given to check.
   let isSchemaRule = Array.isArray(ruleDef.given) && ruleDef.given.every(location => locationsWhereSchemaCanBeUsed.includes(location));

--- a/.github/workflows/schema-validator.yaml
+++ b/.github/workflows/schema-validator.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate OB OpenAPI
         uses: char0n/swagger-editor-validate@master
         with:
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install IBM OpenAPI Validator with Its Spectral OpenAPI Ruleset
-        run: npm install -g ibm-openapi-validator@0.76.2 && npm install @ibm-cloud/openapi-ruleset@0.25.2
+        run: npm install -g ibm-openapi-validator@1.1.1 && npm install @ibm-cloud/openapi-ruleset@1.1.1
       - name: Install Typo.js Spellchecker
-        run: npm install typo-js@1.2.1
+        run: npm install typo-js@1.2.2
       - name: Run validator
         run: lint-openapi Master-OB-OpenAPI.json -r ./.github/configs/schema-validator/.spectral.yaml

--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -1690,6 +1690,7 @@
             "x-ob-item-type": "PerUnitItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "pu",
               "Value": 4
             },
             "x-ob-item-type-group": ""
@@ -3056,6 +3057,7 @@
             "x-ob-item-type": "PureItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "pure",
               "Value": 30
             },
             "x-ob-item-type-group": ""
@@ -3073,6 +3075,7 @@
             "x-ob-item-type": "PureItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "pure",
               "Value": 31
             },
             "x-ob-item-type-group": ""
@@ -6304,9 +6307,6 @@
               "Grounding": {
                 "$ref": "#/components/schemas/Grounding"
               },
-              "Dimension": {
-                "$ref": "#/components/schemas/Dimension"
-              },
               "InverterEfficiency": {
                 "$ref": "#/components/schemas/InverterEfficiency"
               },
@@ -6859,6 +6859,7 @@
             "x-ob-item-type": "TempCoefficientItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "W_per_Cel",
               "Value": -0.37
             },
             "x-ob-item-type-group": ""
@@ -6876,6 +6877,7 @@
             "x-ob-item-type": "TempCoefficientItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "V_per_Cel",
               "Value": -0.304
             },
             "x-ob-item-type-group": ""
@@ -6893,6 +6895,7 @@
             "x-ob-item-type": "TempCoefficientItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "A_per_Cel",
               "Value": 0.05
             },
             "x-ob-item-type-group": ""
@@ -6910,6 +6913,7 @@
             "x-ob-item-type": "TempCoefficientItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "V_per_Cel",
               "Value": -0.304
             },
             "x-ob-item-type-group": ""
@@ -6927,6 +6931,7 @@
             "x-ob-item-type": "TempCoefficientItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "A_per_Cel",
               "Value": 0.05
             },
             "x-ob-item-type-group": ""
@@ -7086,6 +7091,7 @@
             "x-ob-item-type": "PureItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "pure",
               "Value": 3
             },
             "x-ob-item-type-group": ""
@@ -7246,18 +7252,6 @@
               "ProdCell": {
                 "$ref": "#/components/schemas/ProdCell"
               },
-              "ProdCode": {
-                "$ref": "#/components/schemas/ProdCode"
-              },
-              "Description": {
-                "$ref": "#/components/schemas/Description"
-              },
-              "FileFolderURL": {
-                "$ref": "#/components/schemas/FileFolderURL"
-              },
-              "ProdDatasheet": {
-                "$ref": "#/components/schemas/ProdDatasheet"
-              },
               "ProdGlazing": {
                 "$ref": "#/components/schemas/ProdGlazing"
               },
@@ -7272,9 +7266,6 @@
               },
               "CableConnector": {
                 "$ref": "#/components/schemas/CableConnector"
-              },
-              "Dimension": {
-                "$ref": "#/components/schemas/Dimension"
               },
               "PowerToleranceMin": {
                 "$ref": "#/components/schemas/PowerToleranceMin"
@@ -7311,9 +7302,6 @@
               },
               "ShadeResponse": {
                 "$ref": "#/components/schemas/ShadeResponse"
-              },
-              "Warranties": {
-                "$ref": "#/components/schemas/Warranties"
               },
               "CECNotes": {
                 "$ref": "#/components/schemas/CECNotes"
@@ -8584,17 +8572,8 @@
               "Description": {
                 "$ref": "#/components/schemas/Description"
               },
-              "Contacts": {
-                "$ref": "#/components/schemas/Contacts"
-              },
-              "Addresses": {
-                "$ref": "#/components/schemas/Addresses"
-              },
               "FileFolderURL": {
                 "$ref": "#/components/schemas/FileFolderURL"
-              },
-              "URL": {
-                "$ref": "#/components/schemas/URL"
               }
             },
             "x-ob-usage-tips": ""
@@ -10331,9 +10310,6 @@
               "CapacityDC": {
                 "$ref": "#/components/schemas/CapacityDC"
               },
-              "Description": {
-                "$ref": "#/components/schemas/Description"
-              },
               "ElectricalServiceID": {
                 "$ref": "#/components/schemas/ElectricalServiceID"
               },
@@ -11456,9 +11432,6 @@
               "Address": {
                 "$ref": "#/components/schemas/Address"
               },
-              "Contacts": {
-                "$ref": "#/components/schemas/Contacts"
-              },
               "BuildingCode": {
                 "$ref": "#/components/schemas/BuildingCode"
               },
@@ -11510,9 +11483,6 @@
               "FeeStructures": {
                 "$ref": "#/components/schemas/FeeStructures"
               },
-              "URL": {
-                "$ref": "#/components/schemas/URL"
-              },
               "AHJCode": {
                 "$ref": "#/components/schemas/AHJCode"
               },
@@ -11560,9 +11530,6 @@
               "Address": {
                 "$ref": "#/components/schemas/Address"
               },
-              "Contacts": {
-                "$ref": "#/components/schemas/Contacts"
-              },
               "Description": {
                 "$ref": "#/components/schemas/Description"
               },
@@ -11571,9 +11538,6 @@
               },
               "FeeStructures": {
                 "$ref": "#/components/schemas/FeeStructures"
-              },
-              "URL": {
-                "$ref": "#/components/schemas/URL"
               }
             },
             "x-ob-usage-tips": ""


### PR DESCRIPTION
Closes #75, #76, #214, #216.

New rules are added to the taxonomy checker, and its software dependencies are updated.

The new rules are:
- Subclass OB Objects cannot have fields that duplicate/shadow their superclass fields.
- `Unit` is required in sample values when the OB Element's item type defines units.

The spellchecker rule is updated to allow checking for known plural acronyms, such as `AHJs`. Also, new words and acronyms are added to its dictionary.