### PR TITLE
Updates usage tip for StartTime to note usage for snapshot of time.

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -5859,7 +5859,7 @@
       "StartTime": {
         "type": "string",
         "description": "Start time of a measurement period for the instance element",
-        "x-ob-usage-tips": ""
+        "x-ob-usage-tips": "StartTime can be used to note the start of a window of time that a value represents, where EndTime closes time period. In instances where a value represents a snapshot, or single moment in time, StartTime can be used to represent that exact moment in time. "
       },
       "EndTime": {
         "type": "string",

--- a/docs/whatsnew/whatsnew_dev.rst
+++ b/docs/whatsnew/whatsnew_dev.rst
@@ -24,7 +24,7 @@ Testing
 
 Documentation
 ~~~~~~~~~~~~~
-
+ * Updates StartTime documentation to share dual usage purposes of StartTime value. (:pull:`247`)
 
 Contributors
 ~~~~~~~~~~~~


### PR DESCRIPTION
Draft of UsageTip for start time explaining dual usage. 