### PR TITLE
Remove old MonthlyOperatingReport and associated ItemType

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -2961,27 +2961,6 @@
           "$ref": "#/components/schemas/AccountBalance"
         }
       },
-      "MonthlyOperatingReport": {
-        "type": "object",
-        "description": "The Monthly Operating Report Data",
-        "properties": {
-          "AccountBalances": {
-            "$ref": "#/components/schemas/AccountBalances"
-          },
-          "AgingBuckets": {
-            "$ref": "#/components/schemas/AgingBuckets"
-          },
-          "SiteID": {
-            "$ref": "#/components/schemas/SiteID"
-          },
-          "Contacts": {
-            "$ref": "#/components/schemas/Contacts"
-          },
-          "EnergyConsumptions": {
-            "$ref": "#/components/schemas/EnergyConsumptions"
-          }
-        }
-      },
       "AgingBucket": {
         "type": "object",
         "description": "Sum of the aging amounts of transactions for a particular time period",
@@ -15127,23 +15106,6 @@
           "description": ""
         },
         "High": {
-          "label": "",
-          "description": ""
-        }
-      }
-    },
-    "MORLevelItemType": {
-      "description": "",
-      "enums": {
-        "SiteLevel": {
-          "label": "",
-          "description": ""
-        },
-        "FundLevel": {
-          "label": "",
-          "description": ""
-        },
-        "ProjectLevel": {
           "label": "",
           "description": ""
         }

--- a/docs/whatsnew/whatsnew_dev.rst
+++ b/docs/whatsnew/whatsnew_dev.rst
@@ -15,7 +15,7 @@ Object changes
 ~~~~~~~~~~~~~~
  * Removes DeviceWarranty (:pull:`246`)
  * Adds CECPBIMeter, DisplayProximity, DisplayTypes, DisplayIsCECCompliant and CommunicationProtocol to ProdMeter (:pull:`250`)
- * Removes old MonthlyOperatingReport, replaced by OperatingReport (:pull:XXXX)
+ * Removes old MonthlyOperatingReport, replaced by OperatingReport (:pull:`257`)
 
 Unit changes
 ~~~~~~~~~~~~
@@ -23,7 +23,7 @@ Unit changes
  * Removes CertificationTypeProductItemType (:pull:`255`)
  * Creates DisplayTypeItemType, DisplayProximityItemType and enumerated lists for both. (:pull:`250`)
  * Adds IEEE 2030.5 and IEEE 2800 enums to StandardTypeItemType (:pull:`251`)
- * Removes MORLevelItemType (:pull:XXXX)
+ * Removes MORLevelItemType (:pull:`257`)
 
 
 Bug fixes

--- a/docs/whatsnew/whatsnew_dev.rst
+++ b/docs/whatsnew/whatsnew_dev.rst
@@ -15,6 +15,7 @@ Object changes
 ~~~~~~~~~~~~~~
  * Removes DeviceWarranty (:pull:`246`)
  * Adds CECPBIMeter, DisplayProximity, DisplayTypes, DisplayIsCECCompliant and CommunicationProtocol to ProdMeter (:pull:`250`)
+ * Removes old MonthlyOperatingReport, replaced by OperatingReport (:pull:XXXX)
 
 Unit changes
 ~~~~~~~~~~~~
@@ -22,6 +23,8 @@ Unit changes
  * Removes CertificationTypeProductItemType (:pull:`255`)
  * Creates DisplayTypeItemType, DisplayProximityItemType and enumerated lists for both. (:pull:`250`)
  * Adds IEEE 2030.5 and IEEE 2800 enums to StandardTypeItemType (:pull:`251`)
+ * Removes MORLevelItemType (:pull:XXXX)
+
 
 Bug fixes
 ~~~~~~~~~


### PR DESCRIPTION
* Closes #185, #171
* Removes MonthlyOperatingReport, was replaced by OperatingReport in #146 
* Removes MORLevelItemType (not used)