### PR TITLE
Product Registry related updates to enum lists. Updates whatsnew_dev.rst

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -19908,6 +19908,10 @@
         "Other": {
           "label": "Other",
           "description": "Other"
+        },
+        "LeadAcid": {
+          "label": "Lead Acid",
+          "description": "Lead Acid (Non-specific) Please reference detailed Lead Acid type when available."
         }
       }
     },
@@ -20383,6 +20387,10 @@
         "IEEE2800_2022": {
           "label": "IEEE 2800 : 2022",
           "description": "IEEE Standard for Interconnection and Interoperability of Inverter-Based Resources (IBRs) Interconnecting with Associated Transmission Electric Power Systems"
+        },
+        "UL1973_3_2022": {
+          "label": "UL1973 Edition 3: 2022",
+          "description": "Standard For Batteries For Use In Stationary, Vehicle Auxiliary Power And Light Electric Rail (LER) Applications."
         }
       }
     },

--- a/docs/sphinx/source/whatsnew/whatsnew_dev.rst
+++ b/docs/sphinx/source/whatsnew/whatsnew_dev.rst
@@ -24,6 +24,8 @@ Unit changes
  * Adds ProdGenerator and ProdThermostat to ProdTypeItemType.(#332)
  * Adds Aggregator, PropertyOwner, Financier to EntityTypeItemType Enums.(#332)
  * Creates AggregatorTypeItemType, with Utility and ThirdParty as Enums.(#332)
+ * Adds UL1943_3_2022 to CertificationStandardTypeItemType Enum List (#335)
+ * Adds LeadAcid to BatteryChemistryTypeItemType Enum List (#335)
 
 
 Bug fixes


### PR DESCRIPTION
Adds enums for generic Lead Acid battery chemistry type. Adds enum for UL1973 Edition 3: 2022 standard. 