### PR TITLE
Update to CellTechnologyType enum list, update to whatsnew_dev.rst.

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -19723,6 +19723,10 @@
         "ASi_tandem": {
           "label": "aSi tandem",
           "description": "Amorphous silicon tandem"
+        },
+        "ASi_nc": {
+          "label": "a-Si/nc",
+          "description": "Solar cells that combine amorphous silicon (a-Si) and nanocrystalline silicon (nc-Si)."
         }
       }
     },

--- a/docs/sphinx/source/whatsnew/whatsnew_dev.rst
+++ b/docs/sphinx/source/whatsnew/whatsnew_dev.rst
@@ -26,6 +26,7 @@ Unit changes
  * Creates AggregatorTypeItemType, with Utility and ThirdParty as Enums.(#332)
  * Adds UL1943_3_2022 to CertificationStandardTypeItemType Enum List (#335)
  * Adds LeadAcid to BatteryChemistryTypeItemType Enum List (#335)
+ * Adds ASi_nc to CellTechnologyTypeItemType enum list
 
 
 Bug fixes


### PR DESCRIPTION
Adds reference to a-Si/nc cell technologies per request from Yash in response to data from the CEC product list. 