### PR TITLE
Remove empty paths and servers from OpenAPI file

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -5,8 +5,6 @@
     "title": "OB OpenAPI Taxonomy",
     "description": "OB OpenAPI Definitions For Orange Button."
   },
-  "paths": {},
-  "servers": [],
   "components": {
     "schemas": {
       "EnergyModel": {


### PR DESCRIPTION
Removed empty paths and servers sections from the OpenAPI definition.