### PR TITLE
Fix Swagger OpenAPI validation API

### DIFF
--- a/.github/workflows/schema-validator.yaml
+++ b/.github/workflows/schema-validator.yaml
@@ -7,14 +7,18 @@ jobs:
     name: Swagger Editor OAS Validator Remote
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install/Update Packages
-        run: sudo apt-get update && sudo apt-get install -y libnss3 libgdk-pixbuf2.0 libgtk-3-dev libxss-dev libasound2t64
+      - uses: actions/checkout@v6
       - name: Validate OB OpenAPI
-        uses: swaggerexpert/swagger-editor-validate@master
-        with:
-          definition-file: Master-OB-OpenAPI.json
+        run: |
+          # 1. curl: Sends the OB taxonomy to the Swagger's validation API.
+          # 2. jq: Prints the validation error messages in the API response.
+          #   a. jq has exit code 0 if error messages are present.
+          #   b. jq has exit code 4 if no error messages are present.
+          #   c. View the exit code of a program by typing 'echo $?'.
+          # 3. The '!' in front of 'curl' negates the jq exit code.
+          #   a. jq has exit code 0 -> '!' has exit code 1 -> fail GitHub action.
+          #   b. jq has nonzero exit code (e.g., 4) -> '!' has exit code 0 -> do not fail action.
+          ! curl https://validator.swagger.io/validator/debug --silent --data @Master-OB-OpenAPI.json -H 'Content-Type: application/json' | jq --exit-status --raw-output 'select(.messages) | .messages[]'
 
   ob-open-api-validator:
     name: OB OpenAPI Validator


### PR DESCRIPTION
The GitHub workflow job `schema-validator.swagger-editor-oas-validator-remote` no longer works due to some issue with the `swaggerexpert/swagger-editor-validate` dependency. This pull request removes the dependency and has the job call the Swagger OpenAPI validation API directly using `curl`. The Swagger validation API sends a JSON response containing an array of error messages, which `jq` prints out.