### PR TITLE
Fix typo in element ``CountryOfOwnershipforPFE``

### DIFF
--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -15773,8 +15773,8 @@
           "CountryOfOwnershipIsNotPFE": {
             "$ref": "#/components/schemas/CountryOfOwnershipIsNotPFE"
           },
-          "CountryOfOwnershipforPFE": {
-            "$ref": "#/components/schemas/CountryOfOwnershipforPFE"
+          "CountryOfOwnershipForPFE": {
+            "$ref": "#/components/schemas/CountryOfOwnershipForPFE"
           }
         }
       },
@@ -15818,7 +15818,7 @@
           "$ref": "#/components/schemas/SourceCountry"
         }
       },
-      "CountryOfOwnershipforPFE": {
+      "CountryOfOwnershipForPFE": {
         "allOf": [
           {
             "$ref": "#/components/schemas/TaxonomyElementString"


### PR DESCRIPTION
Closes #417.
Change ``CountryOfOwnershipforPFE`` to ``CountryOfOwnershipForPFE``.