### PR TITLE
String OB elements can use item types defining units

### DIFF
--- a/.github/configs/schema-validator/.spectral.yaml
+++ b/.github/configs/schema-validator/.spectral.yaml
@@ -79,10 +79,10 @@ rules:
     description: >-
       Check that the element's OpenAPI type and OB item type are compatible.
       OpenAPI 'integer' and 'number' types are only compatible with OB unit item types.
-      OpenAPI 'string' type is only compatible with OB enum item types.
       OpenAPI 'boolean' type is only compatible with the BooleanItemType.
       For OB item types without enums or units, all schema definitions that use these
       OB item types should have the same OpenAPI type.
+      OpenAPI 'string' type is compatible with both OB enum and unit item types.
     message: '{{error}}'
     given: $.components.schemas[*][?(@property === 'allOf' && @[0].properties && @[0].properties.Value)]
     severity: error

--- a/.github/configs/schema-validator/functions/validateItemTypeAgainstElementType.js
+++ b/.github/configs/schema-validator/functions/validateItemTypeAgainstElementType.js
@@ -14,8 +14,6 @@ export default (input, options, context) => {
     let errorMessageFirstPart = (elementType, isArray) => `This element's Value primitive ${isArray ? 'has items of' : 'is an'} OpenAPI type '${elementType}'`;
     if (numericOpenAPITypes.includes(elementType) && itemTypeDef.enums) {
         return [{ message: `${errorMessageFirstPart(elementType, isArray)}, but the item type '${itemType}' defines 'string' type enumerations.` }];
-    } else if (elementType === 'string' && itemTypeDef.units) {
-        return [{ message: `${errorMessageFirstPart(elementType, isArray)}, but the item type '${itemType}' defines units.` }];
     } else if (elementType === 'boolean' && itemType !== 'BooleanItemType') {
         return [{ message: `${errorMessageFirstPart(elementType, isArray)}, so its item type must be 'BooleanItemType', not '${itemType}'.`}];
     }

--- a/Master-OB-OpenAPI.json
+++ b/Master-OB-OpenAPI.json
@@ -3954,6 +3954,7 @@
             "x-ob-item-type": "UUIDItemType",
             "x-ob-usage-tips": "",
             "x-ob-sample-value": {
+              "Unit": "UUID",
               "Value": "63e32227-7a31-4a0c-a715-20d46315cc9e"
             },
             "x-ob-item-type-group": ""


### PR DESCRIPTION
Closes #431.

Removes the validator check that an OB element using an item type that defines units has a numeric OpenAPI type.
Also, adds a missing `Unit` field in a sample value for an OB element with `UUIDItemType`.